### PR TITLE
Follow symlinks on 'bee new project_name'.

### DIFF
--- a/new.go
+++ b/new.go
@@ -56,7 +56,7 @@ func createApp(cmd *Command, args []string) {
 
 	wgopath := path.SplitList(gopath)
 	for _, wg := range wgopath {
-		wg = path.Join(wg, "src")
+		wg, _ = path.EvalSymlinks(path.Join(wg, "src"))
 
 		if strings.HasPrefix(strings.ToLower(curpath), strings.ToLower(wg)) {
 			haspath = true

--- a/new.go
+++ b/new.go
@@ -58,7 +58,7 @@ func createApp(cmd *Command, args []string) {
 	for _, wg := range wgopath {
 		wg = path.Join(wg, "src")
 
-		if path.HasPrefix(strings.ToLower(curpath), strings.ToLower(wg)) {
+		if strings.HasPrefix(strings.ToLower(curpath), strings.ToLower(wg)) {
 			haspath = true
 			appsrcpath = wg
 			break


### PR DESCRIPTION
I had a few issues using the bee tool to create my first bee project because my $GOPATH had a symlink that needed to be evaluated. This fixes it.

While I was at it, I switched to use strings.HasPrefix instead of path/filepath version which is apparently deprecated. http://golang.org/pkg/path/filepath/#HasPrefix
